### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/functions/global.set_block.html
+++ b/docs/functions/global.set_block.html
@@ -21,7 +21,7 @@
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Places a block at a position</p>
 
-<h3>Remarks</h3><p>This uses <code>/setblock replace</code>, so any valid <a href="https://minecraft.fandom.com/wiki/Argument_types#block_state">block_state</a> will work</p>
+<h3>Remarks</h3><p>This uses <code>/setblock replace</code>, so any valid <a href="https://minecraft.wiki/w/Argument_types#block_state">block_state</a> will work</p>
 </div>
 <div class="tsd-parameters">
 <h4 class="tsd-parameters-title">Parameters</h4>

--- a/luadatapacktypes/src/global.d.ts
+++ b/luadatapacktypes/src/global.d.ts
@@ -60,7 +60,7 @@ declare function get_blockentity(pos : Vec3d) : BlockEntity;
  * Places a block at a position
  * 
  * @remarks
- * This uses `/setblock replace`, so any valid [block_state](https://minecraft.fandom.com/wiki/Argument_types#block_state) will work
+ * This uses `/setblock replace`, so any valid [block_state](https://minecraft.wiki/w/Argument_types#block_state) will work
  * 
  * @param pos Position
  * @param id Block


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.